### PR TITLE
reqcheck: If module name already starts with "python-", don't prepend it...

### DIFF
--- a/rdopkg/actionmods/pymod2pkg.py
+++ b/rdopkg/actionmods/pymod2pkg.py
@@ -33,7 +33,12 @@ class MultiRule(TranslationRule):
 
 
 def default_tr(mod):
-        return 'python-' + mod.replace('_', '-').replace('.', '-').lower()
+    pkg = mod.rsplit('-python')[0]
+    pkg = pkg.replace('_', '-').replace('.', '-').lower()
+    if pkg.startswith('python-'):
+        return pkg
+    else:
+        return 'python-' + pkg
 
 
 def exact_tr(mod):
@@ -57,6 +62,7 @@ RPM_PKG_MAP = [
     SingleRule('pastedeploy', 'python-paste-deploy'),
     SingleRule('sqlalchemy-migrate', 'python-migrate'),
     SingleRule('qpid-python', 'python-qpid'),
+    SingleRule('posix_ipc', 'python-posix_ipc'),
     MultiRule(
         mods=['PyYAML', 'm2crypto', 'numpy', 'pyflakes', 'pylint', 'pyparsing',
               'pytz', 'pysendfile', 'libvirt-python'],

--- a/rdopkg/actionmods/reqs.py
+++ b/rdopkg/actionmods/reqs.py
@@ -146,7 +146,7 @@ def print_reqcheck(met, any_version, wrong_version, missing):
     cats = [
         ("\n{t.bold_green}MET{t.normal}:", met),
         ("\n{t.bold}VERSION NOT ENFORCED{t.normal}:", any_version),
-        ("\n{t.bold_yellow}VERSION MISSMATCH{t.normal}:", wrong_version),
+        ("\n{t.bold_yellow}VERSION MISMATCH{t.normal}:", wrong_version),
         ("\n{t.bold_red}MISSING{t.normal}:", missing),
         ]
     for title, reqs in cats:


### PR DESCRIPTION
... twice

Drop trailing "-python" (ie: msgpack-python)
Add mapping for python-posix_ipc