### PR TITLE
Handle version_tag_style in check_new_patches()

### DIFF
--- a/rdopkg/actions.py
+++ b/rdopkg/actions.py
@@ -636,7 +636,8 @@ def rebase_patches_branch(new_version, local_patches_branch,
 
 
 def check_new_patches(version, local_patches_branch, local_patches=False,
-                      patches_branch=None, changes=None):
+                      patches_branch=None, changes=None,
+                      version_tag_style=None):
     if not changes:
         changes = []
     if local_patches:
@@ -648,7 +649,8 @@ def check_new_patches(version, local_patches_branch, local_patches=False,
         head = patches_branch
     spec = specfile.Spec()
     n_patches = spec.get_n_patches() + spec.get_n_excluded_patches()
-    patches = git.get_commit_subjects(version, head)
+    version_tag = guess.version2tag(version, version_tag_style)
+    patches = git.get_commit_subjects(version_tag, head)
     if n_patches > 0:
         patches = patches[0:-n_patches]
     if not patches:


### PR DESCRIPTION
This step got missed when adding support vX.Y.Z style tags.

Before this change, I was seeing output like:

```
## check_new_patches
command failed: git log --format=%s 1.5.25..patches/ceph-1.3-rhel-7-patches
stderr:
fatal: ambiguous argument '1.5.25..patches/ceph-1.3-rhel-7-patches': unknown revision or path not in the working tree.
```

The issue is that `1.5.25` is not the tag, `v1.5.25` is, and the tool knows it:

```
$ rdopkg pkgenv
## get_package_env
## show_package_env

Package:   ceph-deploy
Version:   1.5.25
Upstream:  1.5.26
Tag style: vX.Y.Z
OS dist:   RDO
```