### PR TITLE
update-patches: ignore git submodule changes

### DIFF
--- a/rdopkg/actions.py
+++ b/rdopkg/actions.py
@@ -822,7 +822,8 @@ def update_patches(branch, local_patches_branch,
             log.info("%s  %s" % (hsh, title))
 
         rng = git.rev_range(start_commit + '~', local_patches_branch)
-        o = git('format-patch', '--no-renames', '--no-signature', '-N', rng)
+        o = git('format-patch', '--no-renames', '--no-signature', '-N',
+                '--ignore-submodules', rng)
         patch_fns = git._parse_output(o)
         for pfn in patch_fns:
             git('add', pfn)


### PR DESCRIPTION
Prior to this change, rdopkg would create patch files that included Git submodule changes. During the RPM's "prep" stage, `/usr/bin/patch` did not understand what to do with these, and would fail with an error.

With this change, rdopkg will create an empty .patch file instead. `/usr/bin/patch` is able to process this successfully.

This doesn't make rdopkg aware of code changes *within* Git submodules (#16), but at least it will no longer construct unusable patch files when a submodule does change.