### PR TITLE
update-patches: update the "%commit" macro

### DIFF
--- a/doc/rdopkg.1.txt
+++ b/doc/rdopkg.1.txt
@@ -184,6 +184,11 @@ detection.
  * Export patches from patches branch using `git format-patch`
  * Add these patches to dist-git and edit `.spec` file to apply them
  * Create new commit with the change (or amend previous with `-a`/`--amend`)
+ * If a "%global commit asdf1234" macro declaration is present, rewrite
+   it with the current sha1 of the patches branch. (This makes the sha1
+   value available during your package's build process. You can use this
+   to build your program so that "mycoolprogram --version" could display
+   the sha1 to users.)
 
 *Example:*
 

--- a/rdopkg/actions.py
+++ b/rdopkg/actions.py
@@ -800,6 +800,8 @@ def update_patches(branch, local_patches_branch,
             git('add', pfn)
 
     spec.set_new_patches(patch_fns)
+    patches_branch_ref = git('rev-parse', local_patches_branch)
+    spec.set_commit_ref_macro(patches_branch_ref)
     spec.save()
     if git.is_clean():
         log.info('No new patches.')

--- a/rdopkg/utils/specfile.py
+++ b/rdopkg/utils/specfile.py
@@ -245,6 +245,11 @@ class Spec(object):
             return 'autosetup'
         return 'rpm'
 
+    def set_commit_ref_macro(self, ref):
+        self._txt = re.sub(
+            r'^\%global commit \w+',
+            '%%global commit %s' % ref, self.txt, flags=re.M)
+
     def set_new_patches(self, fns):
         self.wipe_patches()
         if not fns:

--- a/tests/assets/spec/commit-patched/foo.spec
+++ b/tests/assets/spec/commit-patched/foo.spec
@@ -1,0 +1,48 @@
+Name:             foo
+Epoch:            1
+Version:          1.2.3
+Release:          42%{?dist}
+Summary:          Some package, dude
+
+Group:            Development/Languages
+License:          ASL 2.0
+URL:              http://pypi.python.org/pypi/%{name}
+Source0:          http://pypi.python.org/packages/source/f/%{name}/%{name}-%{version}.tar.gz
+
+%global commit 86a713c35718520cb3b681260182a8388ac809f3
+
+BuildArch:        noarch
+BuildRequires:    python-setuptools
+BuildRequires:    python2-devel
+
+Requires:         python-argparse
+Requires:         python-iso8601
+Requires:         python-prettytable
+
+%description
+This is foo! This is foo! This is foo! This is foo! This is foo! This is foo!
+This is foo! This is foo! This is foo! 
+
+%prep
+%setup -q
+
+# Insert git commit so that it'll show up in `foo --version`
+echo "version = '%{commit}'" >> version.py
+
+%build
+%{__python} setup.py build
+
+%install
+%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+
+
+%files
+%doc README.rst
+%{_bindir}/foo
+
+%changelog
+* Mon Apr 07 2014 Jakub Ruzicka <jruzicka@redhat.com> 1.2.3-42
+- Update to upstream 1.2.3
+
+* Tue Mar 25 2014 Jakub Ruzicka <jruzicka@redhat.com> 1.2.2-1
+- Update to upstream 1.2.2

--- a/tests/assets/spec/commit/foo.spec
+++ b/tests/assets/spec/commit/foo.spec
@@ -1,0 +1,48 @@
+Name:             foo
+Epoch:            1
+Version:          1.2.3
+Release:          42%{?dist}
+Summary:          Some package, dude
+
+Group:            Development/Languages
+License:          ASL 2.0
+URL:              http://pypi.python.org/pypi/%{name}
+Source0:          http://pypi.python.org/packages/source/f/%{name}/%{name}-%{version}.tar.gz
+
+%global commit asdf123456
+
+BuildArch:        noarch
+BuildRequires:    python-setuptools
+BuildRequires:    python2-devel
+
+Requires:         python-argparse
+Requires:         python-iso8601
+Requires:         python-prettytable
+
+%description
+This is foo! This is foo! This is foo! This is foo! This is foo! This is foo!
+This is foo! This is foo! This is foo! 
+
+%prep
+%setup -q
+
+# Insert git commit so that it'll show up in `foo --version`
+echo "version = '%{commit}'" >> version.py
+
+%build
+%{__python} setup.py build
+
+%install
+%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+
+
+%files
+%doc README.rst
+%{_bindir}/foo
+
+%changelog
+* Mon Apr 07 2014 Jakub Ruzicka <jruzicka@redhat.com> 1.2.3-42
+- Update to upstream 1.2.3
+
+* Tue Mar 25 2014 Jakub Ruzicka <jruzicka@redhat.com> 1.2.2-1
+- Update to upstream 1.2.2

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -82,3 +82,12 @@ def test_patches_base_noop_weird(tmpdir):
         spec.save()
         spec_after = spec_path.read()
     common.assert_distgit(dist_path, 'empty-weird')
+
+def test_set_commit_ref_macro(tmpdir):
+    dist_path = common.prep_spec_test(tmpdir, 'commit')
+    spec_path = dist_path.join('foo.spec')
+    with dist_path.as_cwd():
+        spec = specfile.Spec()
+        spec.set_commit_ref_macro('86a713c35718520cb3b681260182a8388ac809f3')
+        spec.save()
+    common.assert_distgit(dist_path, 'commit-patched')


### PR DESCRIPTION
With this change, `rdopkg update-patches` will rewrite the `%{commit}` macro in your package's spec file so that it includes the sha1 of the the patches branch.

For example, after `rdopkg update-patches`, my ceph.spec has the following change:

```
  -%global commit asdf
  +%global commit 6a8df8baa02c566d11a9b188691bd3252a266da8
```
It is useful to incorporate this sha1 string into Ceph's build system so that we can see exactly what build a user is running. Ceph prints this value in several places (each of Ceph's client and server binaries have a "`--version`" option, and the version is written to all the logs, etc).