### PR TITLE
Reqcheck: small display improvement

### DIFF
--- a/rdopkg/actionmods/reqs.py
+++ b/rdopkg/actionmods/reqs.py
@@ -14,6 +14,8 @@ from rdopkg import helpers
 class DiffReq(object):
     def __init__(self, name, vers):
         self.name = name
+        # ensure that comp. operators are surrounded with spaces
+        vers = re.sub(r'([<>=!]+)', r'\1 ', vers)
         self.vers = vers
         self.old_vers = vers
 

--- a/rdopkg/utils/specfile.py
+++ b/rdopkg/utils/specfile.py
@@ -414,7 +414,7 @@ class Spec(object):
                         _, sep, rest = ver.partition(':')
                         if sep:
                             ver = rest
-                    reqs[name].add(eq + ver)
+                    reqs[name].add(eq + ' ' +ver)
                 else:
                     name = req.N()
                     reqs[name]


### PR DESCRIPTION
Packagers are tempted into copy/pasting the output of reqcheck but
RPM specfile parsers enforces that comparison operators are surrounded
with spaces.