### PR TITLE
Add support for git repos using authenticated ssh, review related functions

### DIFF
--- a/rdopkg/helpers.py
+++ b/rdopkg/helpers.py
@@ -92,6 +92,20 @@ def cdir(path):
         os.chdir(prev_cwd)
 
 
+@contextlib.contextmanager
+def setenv(**env_dict):
+    orig_env = os.environ.copy()
+    for k, v in env_dict.items():
+        os.environ[k] = str(v)
+    try:
+        yield
+    finally:
+        for k, v in env_dict.items():
+            del os.environ[k]
+        for k, v in orig_env.items():
+            os.environ[k] = v
+
+
 def print_keyval(key, val, kb=True, vb=False):
     if kb:
         fmt = '{t.bold}{key}{t.normal}: '


### PR DESCRIPTION
This allows RepoManager to handle repos using authentication with the
ssh protocol (for example like the ones handled by a gerrit instance)
If a user isn't provided, the local user or the env variable $USERNAME
if set will be used as a the user.
Also adds review related functions: setup (git review -s), send review
(git review) and download review (git review -d XXX)